### PR TITLE
Allow large Linux IDs

### DIFF
--- a/graphalytics-core/pom.xml
+++ b/graphalytics-core/pom.xml
@@ -42,6 +42,7 @@
 							<goal>single</goal>
 						</goals>
 						<configuration>
+							<tarLongFileMode>posix</tarLongFileMode>
 							<descriptors>
 								<descriptor>src/main/assembly/resources.xml</descriptor>
 							</descriptors>


### PR DESCRIPTION
This fixes an error I am getting because of my Linux user ID.

See the Maven Assembly Plugin FAQ:
https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes