### PR TITLE
Fix null pointer error in constructBenchmark

### DIFF
--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/configuration/BenchmarkSuiteParser.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/configuration/BenchmarkSuiteParser.java
@@ -194,6 +194,11 @@ public final class BenchmarkSuiteParser {
 
 		Map<Algorithm, AlgorithmParameters> algorithmParameters = algorithmParametersPerGraphSet.get(graphName);
 		Map<Algorithm, Graph> graphPerAlgorithm = graphSets.get(graphName).getGraphPerAlgorithm();
+                if (graphPerAlgorithm.get(algorithm) == null) {
+			throw new InvalidConfigurationException(String.format(
+                                    "Benchmark includes algorithm %s, which is not configured for graph %s.",
+                                    algorithm.getAcronym(), graphName));
+                }
 
 		String graphAlgorithmKey = graphName + "-" + algorithm.getAcronym();
 


### PR DESCRIPTION
If a benchmark configuration includes an algorithm which is not configured for
a graph, a null pointer exception is thrown. Instead, check and throw an
InvalidConfigurationException.