### PR TITLE
Add maven-source-plugin to include source code in generated JAR files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,19 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Stumbled upon this while working on https://github.com/atlarge-research/graphalytics-platforms-neo4j/pull/6.