### PR TITLE
Remove build badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
     A Big Data Benchmark For Graph-Processing Platforms
 </p>
 
-[![Build Status](https://jenkins.tribler.org/buildStatus/icon?job=Graphalytics/Core_master)](https://jenkins.tribler.org/job/Graphalytics/job/Core_master/)
-
 Graph processing is of increasing interest for many scientific areas and revenue-generating applications, such as social networking, bioinformatics, online retail, and online gaming. To address the growing diversity of graph datasets and graph-processing algorithms, developers and system integrators have created a large variety of graph-processing platforms, which we define as the combined hardware, software, and programming system that is being used to complete a graph processing task. **LDBC Graphalytics**, an industrial-grade benchmark under [LDBC](http://ldbcouncil.org), is developed to enable objective comparisons between graph processing platforms by using six representative graph algorithms, and a large variety of real-world and synthetic datasets. Visit [our website](https://graphalytics.org) for the most recent updates of the Graphalytics project.
 
 ### Publication


### PR DESCRIPTION
What is the status of the build server? Will it go back up? If not, we should just delete the badge.