### PR TITLE
Add link to spec repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Graph processing is of increasing interest for many scientific areas and revenue-generating applications, such as social networking, bioinformatics, online retail, and online gaming. To address the growing diversity of graph datasets and graph-processing algorithms, developers and system integrators have created a large variety of graph-processing platforms, which we define as the combined hardware, software, and programming system that is being used to complete a graph processing task. **LDBC Graphalytics**, an industrial-grade benchmark under [LDBC](http://ldbcouncil.org), is developed to enable objective comparisons between graph processing platforms by using six representative graph algorithms, and a large variety of real-world and synthetic datasets. Visit [our website](https://graphalytics.org) for the most recent updates of the Graphalytics project.
 
 ### Publication
-Want to know more about Graphalytics? Read [our VLDB paper](http://www.vldb.org/pvldb/vol9/p1317-iosup.pdf).
+Want to know more about Graphalytics? Read [our VLDB paper](http://www.vldb.org/pvldb/vol9/p1317-iosup.pdf) and the [specification](https://github.com/ldbc/ldbc_graphalytics_docs).
 
 ### Build & Run your first benchmark
 Graphalytics provides [a list of platform drivers](https://graphalytics.org/software) for the state-of-the-arts graph processing platforms. To start your first benchmark with Graphalytics, download the benchmark software from our repository and follow the detailed instructions in the manual on [Building the Software](https://github.com/ldbc/ldbc_graphalytics/wiki/Documentation%3A-Software-Build) and [Running a Benchmark](https://github.com/ldbc/ldbc_graphalytics/wiki/Manual:-Running-Benchmark).


### PR DESCRIPTION
I linked the detailed spec, which is only linked at https://graphalytics.org/docs, but not in this repo.