### PR TITLE
Omit forced System.exit(0) at the end of the program

### DIFF
--- a/graphalytics-core/src/main/java/science/atlarge/graphalytics/BenchmarkSuite.java
+++ b/graphalytics-core/src/main/java/science/atlarge/graphalytics/BenchmarkSuite.java
@@ -129,8 +129,6 @@ public class BenchmarkSuite {
 		ConsoleUtil.displayTrademark(platform.getPlatformName());
 
 		LOG.info(String.format("Terminating Benchmark Suite."));
-
-		System.exit(0);
 	}
 
 }


### PR DESCRIPTION
DuckDB deletes its temp file on exit, which a forced exit prevents:
https://github.com/duckdb/duckdb/blob/3dcba6d0b59d50a5cb23a9878ed2847f654712d4/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java#L51

This, temp directories (`/tmp` on Linux and temp directories on MacOS under `/private/var/folders/`) are filled up by `libduckdb_java*.so` files.